### PR TITLE
[feat] implement mint precompile

### DIFF
--- a/precompiles/common/interfaces.go
+++ b/precompiles/common/interfaces.go
@@ -26,6 +26,9 @@ type BankKeeper interface {
 	SendCoins(ctx context.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	SpendableCoin(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
 	BlockedAddr(addr sdk.AccAddress) bool
+	// minting capability for mint precompile.
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 }
 
 type TransferKeeper interface {

--- a/precompiles/mint/IMint.sol
+++ b/precompiles/mint/IMint.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface for the Mint precompile contract.
+ * This precompile allows authorized accounts to mint native Cosmos tokens.
+ */
+interface IMint {
+    /**
+     * @dev Emitted when tokens are minted to an account.
+     * @param to The address that received the minted tokens
+     * @param token The denomination of the token that was minted
+     * @param value The amount of tokens that were minted
+     */
+    event Mint(address indexed to, string token, uint256 value);
+
+    /**
+     * @dev Mint native tokens to the specified address.
+     * Can only be called by the authorized admin account.
+     *
+     * @param to The address to receive the minted tokens
+     * @param token The token denomination to mint (e.g., "umint", "uatom")
+     * @param value The amount of tokens to mint
+     *
+     * Requirements:
+     * - Caller must be the authorized admin
+     * - `to` cannot be the zero address
+     * - `to` cannot be a smart contract or module account
+     * - `token` must be a valid denomination
+     * - `value` must be greater than zero
+     *
+     * Emits a {Mint} event.
+     */
+    function mint(address to, string calldata token, uint256 value) external;
+}

--- a/precompiles/mint/abi.json
+++ b/precompiles/mint/abi.json
@@ -1,0 +1,59 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IMint",
+  "sourceName": "solidity/precompiles/mint/IMint.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "token",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Mint",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "token",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/precompiles/mint/errors.go
+++ b/precompiles/mint/errors.go
@@ -4,8 +4,13 @@ import "errors"
 
 const (
 	ErrInvalidRecipient = "invalid recipient address: %s"
+	ErrInvalidDenom     = "invalid token denomination: %s"
+	ErrMintFailed       = "failed to mint tokens: %s"
+	ErrTransferFailed   = "failed to transfer tokens: %s"
 )
 
 var (
-	ErrUnauthorized = errors.New("caller is not authorized to mint tokens")
+	ErrUnauthorized   = errors.New("caller is not authorized to mint tokens")
+	ErrZeroAmount     = errors.New("cannot mint zero amount of tokens")
+	ErrNegativeAmount = errors.New("cannot mint negative amount of tokens")
 )

--- a/precompiles/mint/errors.go
+++ b/precompiles/mint/errors.go
@@ -3,10 +3,11 @@ package mint
 import "errors"
 
 const (
-	ErrInvalidRecipient = "invalid recipient address: %s"
-	ErrInvalidDenom     = "invalid token denomination: %s"
-	ErrMintFailed       = "failed to mint tokens: %s"
-	ErrTransferFailed   = "failed to transfer tokens: %s"
+	ErrCannotReceiveFunds = "cannot receive funds, received: %s"
+	ErrInvalidRecipient   = "invalid recipient address: %s"
+	ErrInvalidDenom       = "invalid token denomination: %s"
+	ErrMintFailed         = "failed to mint tokens: %s"
+	ErrTransferFailed     = "failed to transfer tokens: %s"
 )
 
 var (

--- a/precompiles/mint/errors.go
+++ b/precompiles/mint/errors.go
@@ -2,6 +2,10 @@ package mint
 
 import "errors"
 
+const (
+	ErrInvalidRecipient = "invalid recipient address: %s"
+)
+
 var (
 	ErrUnauthorized = errors.New("caller is not authorized to mint tokens")
 )

--- a/precompiles/mint/errors.go
+++ b/precompiles/mint/errors.go
@@ -1,0 +1,7 @@
+package mint
+
+import "errors"
+
+var (
+	ErrUnauthorized = errors.New("caller is not authorized to mint tokens")
+)

--- a/precompiles/mint/events.go
+++ b/precompiles/mint/events.go
@@ -19,7 +19,7 @@ const (
 )
 
 // EmitMintEvent creates a new Mint event emitted on mint transactions
-func (p Precompile) EmitMintEvent(ctx sdk.Context, stateDB vm.StateDB, to common.Address, token string, value *big.Int) error {
+func (p *Precompile) EmitMintEvent(ctx sdk.Context, stateDB vm.StateDB, to common.Address, token string, value *big.Int) error {
 	// Prepare the event topics
 	event := p.Events[EventTypeMint]
 	topics := make([]common.Hash, 2)

--- a/precompiles/mint/events.go
+++ b/precompiles/mint/events.go
@@ -1,0 +1,51 @@
+package mint
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+
+	cmn "github.com/cosmos/evm/precompiles/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	// EventTypeMint defines the event type for the Mint transaction
+	EventTypeMint = "Mint"
+)
+
+// EmitMintEvent creates a new Mint event emitted on mint transactions
+func (p Precompile) EmitMintEvent(ctx sdk.Context, stateDB vm.StateDB, to common.Address, token string, value *big.Int) error {
+	// Prepare the event topics
+	event := p.Events[EventTypeMint]
+	topics := make([]common.Hash, 2)
+
+	// The first topic is always the signature of the event
+	topics[0] = event.ID
+
+	var err error
+	topics[1], err = cmn.MakeTopic(to)
+	if err != nil {
+		return err
+	}
+
+	// Pack the non-indexed parameters (token and value)
+	arguments := abi.Arguments{event.Inputs[1], event.Inputs[2]}
+	packed, err := arguments.Pack(token, value)
+	if err != nil {
+		return err
+	}
+
+	stateDB.AddLog(&ethtypes.Log{
+		Address:     p.Address(),
+		Topics:      topics,
+		Data:        packed,
+		BlockNumber: uint64(ctx.BlockHeight()),
+	})
+
+	return nil
+}

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -26,7 +26,8 @@ const (
 )
 
 // Embed abi json file to the executable binary.
-// go:embed abi.json
+//
+//go:embed abi.json
 var f embed.FS
 
 var _ vm.PrecompiledContract = &Precompile{}

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -47,3 +47,13 @@ func NewPrecompile(authority string, bankKeeper cmn.BankKeeper) (*Precompile, er
 
 	return p, nil
 }
+
+func (p Precompile) RequiredGas(input []byte) uint64 {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -9,6 +9,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
+// Precompile defines the precompiled contract for Mint.
+type Precompile struct {
+	cmn.Precompile
+	authority  string
+	bankKeeper cmn.BankKeeper
+}
+
 const (
 	abiPath = "abi.json"
 	GasMint = 25_000

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -1,0 +1,4 @@
+package mint
+
+type Precompile struct {
+}

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -49,13 +49,14 @@ func NewPrecompile(authority string, bankKeeper cmn.BankKeeper) (*Precompile, er
 	}
 
 	// Set the address of the Mint precompile contract. would use 0x1111 for easy testing
+	// TODO:
 	p.SetAddress(common.HexToAddress("0x0000000000000000000000000000000000001111"))
 
 	return p, nil
 }
 
 // RequiredGas calculates the contract gas used.
-func (p Precompile) RequiredGas(input []byte) uint64 {
+func (p *Precompile) RequiredGas(input []byte) uint64 {
 	if len(input) < 4 {
 		return 0
 	}
@@ -75,7 +76,7 @@ func (p Precompile) RequiredGas(input []byte) uint64 {
 }
 
 // Run executes the precompiled contract Mint method defined in the ABI.
-func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) (bz []byte, err error) {
+func (p *Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) (bz []byte, err error) {
 	bz, err = p.run(evm, contract, readonly)
 	if err != nil {
 		return cmn.ReturnRevertError(evm, err)
@@ -84,7 +85,7 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) (bz [
 	return bz, nil
 }
 
-func (p Precompile) run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
+func (p *Precompile) run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
 	// Mint precompile cannot receive funds.
 	if value := contract.Value(); value.Sign() == 1 {
 		return nil, fmt.Errorf(ErrCannotReceiveFunds, contract.Value().String())
@@ -113,7 +114,7 @@ func (p Precompile) run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]by
 }
 
 // IsTransaction checks if the given method name corresponds to a transaction or query.
-func (Precompile) IsTransaction(method *abi.Method) bool {
+func (p *Precompile) IsTransaction(method *abi.Method) bool {
 	switch method.Name {
 	case MintMethod:
 		return true

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -2,10 +2,14 @@ package mint
 
 import (
 	"embed"
+	"fmt"
 
 	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -21,11 +25,13 @@ const (
 	GasMint = 25_000
 )
 
+// Embed abi json file to the executable binary.
+// go:embed abi.json
 var f embed.FS
 
 var _ vm.PrecompiledContract = &Precompile{}
 
-// NewPRecompile creates a new Mint Precompile instance as a PrecompiledContract interface.
+// NewPrecompile creates a new Mint Precompile instance as a PrecompiledContract interface.
 func NewPrecompile(authority string, bankKeeper cmn.BankKeeper) (*Precompile, error) {
 	newABI, err := cmn.LoadABI(f, abiPath)
 	if err != nil {
@@ -48,12 +54,88 @@ func NewPrecompile(authority string, bankKeeper cmn.BankKeeper) (*Precompile, er
 	return p, nil
 }
 
+// RequiredGas calculates the contract gas used.
 func (p Precompile) RequiredGas(input []byte) uint64 {
-	//TODO implement me
-	panic("implement me")
+	if len(input) < 4 {
+		return 0
+	}
+
+	methodID := input[:4]
+	method, err := p.MethodById(methodID)
+	if err != nil {
+		return 0
+	}
+
+	switch method.Name {
+	case MintMethod:
+		return GasMint
+	default:
+		return 0
+	}
 }
 
-func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
-	//TODO implement me
-	panic("implement me")
+// Run executes the precompiled contract Mint method defined in the ABI.
+func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) (bz []byte, err error) {
+	bz, err = p.run(evm, contract, readonly)
+	if err != nil {
+		return cmn.ReturnRevertError(evm, err)
+	}
+
+	return bz, nil
+}
+
+func (p Precompile) run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
+	// Mint precompile cannot receive funds.
+	if value := contract.Value(); value.Sign() == 1 {
+		return nil, fmt.Errorf(ErrCannotReceiveFunds, contract.Value().String())
+	}
+
+	ctx, stateDB, method, initialGas, args, err := p.RunSetup(evm, contract, readonly, p.IsTransaction)
+	if err != nil {
+		return nil, err
+	}
+
+	// If there's any error so far during execution, don't panic, just return OOG error so EVM can continue running.
+	defer cmn.HandleGasError(ctx, contract, initialGas, &err)()
+
+	bz, err := p.HandleMethod(ctx, contract, stateDB, method, args)
+	if err != nil {
+		return nil, err
+	}
+
+	cost := ctx.GasMeter().GasConsumed() - initialGas
+
+	if !contract.UseGas(cost, nil, tracing.GasChangeCallPrecompiledContract) {
+		return nil, vm.ErrOutOfGas
+	}
+
+	return bz, nil
+}
+
+// IsTransaction checks if the given method name corresponds to a transaction or query.
+func (Precompile) IsTransaction(method *abi.Method) bool {
+	switch method.Name {
+	case MintMethod:
+		return true
+	default:
+		return false
+	}
+}
+
+// HandleMethod handles the execution of each of the Mint methods.
+func (p *Precompile) HandleMethod(
+	ctx sdk.Context,
+	contract *vm.Contract,
+	stateDB vm.StateDB,
+	method *abi.Method,
+	args []interface{},
+) (bz []byte, err error) {
+	switch method.Name {
+	case MintMethod:
+		bz, err = p.Mint(ctx, contract, stateDB, method, args)
+	default:
+		return nil, fmt.Errorf(cmn.ErrUnknownMethod, method.Name)
+	}
+
+	return bz, err
 }

--- a/precompiles/mint/mint.go
+++ b/precompiles/mint/mint.go
@@ -1,4 +1,42 @@
 package mint
 
-type Precompile struct {
+import (
+	"embed"
+
+	storetypes "cosmossdk.io/store/types"
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+const (
+	abiPath = "abi.json"
+	GasMint = 25_000
+)
+
+var f embed.FS
+
+var _ vm.PrecompiledContract = &Precompile{}
+
+// NewPRecompile creates a new Mint Precompile instance as a PrecompiledContract interface.
+func NewPrecompile(authority string, bankKeeper cmn.BankKeeper) (*Precompile, error) {
+	newABI, err := cmn.LoadABI(f, abiPath)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Precompile{
+		Precompile: cmn.Precompile{
+			ABI:                  newABI,
+			KvGasConfig:          storetypes.GasConfig{},
+			TransientKVGasConfig: storetypes.GasConfig{},
+		},
+		authority:  authority,
+		bankKeeper: bankKeeper,
+	}
+
+	// Set the address of the Mint precompile contract. would use 0x1111 for easy testing
+	p.SetAddress(common.HexToAddress("0x0000000000000000000000000000000000001111"))
+
+	return p, nil
 }

--- a/precompiles/mint/tx.go
+++ b/precompiles/mint/tx.go
@@ -3,6 +3,7 @@ package mint
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -18,4 +19,15 @@ func (p *Precompile) Mint(ctx sdk.Context, contract *vm.Contract, stateDB vm.Sta
 	if !p.isAuthorized(ctx, caller) {
 		return nil, ErrUnauthorized
 	}
+	
+	// todo
+}
+
+// isAuthorized checks if the caller is the authorized admin.
+func (p *Precompile) isAuthorized(ctx sdk.Context, caller common.Address) bool {
+	// Convert EVM address to bech32 for comparison
+	callerBech32 := sdk.AccAddress(caller.Bytes()).String()
+
+	// Support both hex and bech32 formats
+	return caller.Hex() == p.authority || callerBech32 == p.authority
 }

--- a/precompiles/mint/tx.go
+++ b/precompiles/mint/tx.go
@@ -85,5 +85,6 @@ func (p *Precompile) isAuthorized(ctx sdk.Context, caller common.Address) bool {
 // isValidRecipient ensures the recipient is a valid user account and not a contract or module account
 func (p *Precompile) isValidRecipient(_ctx sdk.Context, to common.Address) bool {
 	// TODO: check if address has contract code...
+	// Could do this better in prod. Like checking against a list of known module addresses.
 	return !to.Big().IsUint64() || to != common.HexToAddress("0x0")
 }

--- a/precompiles/mint/tx.go
+++ b/precompiles/mint/tx.go
@@ -1,0 +1,21 @@
+package mint
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+const (
+	// MintMethod defines the ABI method name for the mint transaction
+	MintMethod = "mint"
+)
+
+// Mint mints native tokens to the specified address
+func (p *Precompile) Mint(ctx sdk.Context, contract *vm.Contract, stateDB vm.StateDB, method *abi.Method, args []interface{}) ([]byte, error) {
+	// First check if the caller is authorized
+	caller := contract.Caller()
+	if !p.isAuthorized(ctx, caller) {
+		return nil, ErrUnauthorized
+	}
+}

--- a/precompiles/mint/types.go
+++ b/precompiles/mint/types.go
@@ -1,0 +1,45 @@
+package mint
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EventMint defines the event data for the Mint event
+type EventMint struct {
+	To    common.Address
+	Token string
+	Value *big.Int
+}
+
+// ParseMintArgs parses the arguments from the mint method and returns
+// the recipient address, token denomination, and amount.
+func ParseMintArgs(args []interface{}) (
+	to common.Address, token string, value *big.Int, err error,
+) {
+	if len(args) != 3 {
+		return common.Address{}, "", nil, fmt.Errorf("invalid number of arguments; expected 3; got: %d", len(args))
+	}
+
+	// Parse "to" address
+	to, ok := args[0].(common.Address)
+	if !ok {
+		return common.Address{}, "", nil, fmt.Errorf("invalid `to` address: %v", args[0])
+	}
+
+	// Parse 'token' string
+	token, ok = args[1].(string)
+	if !ok {
+		return common.Address{}, "", nil, fmt.Errorf("invalid `token`: %v", args[1])
+	}
+
+	// And finally parse 'value' big.Int
+	value, ok = args[2].(*big.Int)
+	if !ok {
+		return common.Address{}, "", nil, fmt.Errorf("invalid `value`: %v", args[2])
+	}
+
+	return to, token, value, nil
+}


### PR DESCRIPTION
## Brief

- read through ERC20 precompile codes to get idea of pattern to follow
- create mint precompile based on that
- add types and parsers
- implement the solidity interface for Mint, add an abi matching it. TODO: compile the contract using abigen
- add minting capability to bankkeeper's interferface
- handle the mint method
- nit fixes.

Next PR will integrate the mint precompile with the EVM module (searching for where to do this).